### PR TITLE
DE7227

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -227,6 +227,13 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "aws-sign2": {
@@ -1600,9 +1607,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "newrelic": "^5.8.0",
     "stripchar": "^1.2.1",
     "ts-node": "^8.1.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.4.5",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "tslint": "^5.16.0"

--- a/src/models/contentful-data.model.ts
+++ b/src/models/contentful-data.model.ts
@@ -1,6 +1,7 @@
 import * as contentfulService from "../services/contentful.service";
 
 var stripchar = require('stripchar').StripChar;
+const uuidv1 = require('uuid/v1');
 
 export class ContentData {
   id: string;
@@ -10,6 +11,7 @@ export class ContentData {
   transcriptionUrl: string;
   transcriptionId: string;
   bitmovinUrl: string;
+  requestId: string;
   
   constructor(id: string, title: string, videoUrl: string, videoId: string, transcriptionUrl: string, transcriptionId: string, bitmovinUrl: string) {
     this.id = id;
@@ -19,6 +21,7 @@ export class ContentData {
     this.transcriptionUrl = transcriptionUrl;
     this.transcriptionId = transcriptionId;
     this.bitmovinUrl = bitmovinUrl;
+    this.requestId = uuidv1();
   };
 
   public static createContentfulDataArray(entries: any[]): Promise<ContentData>[] {

--- a/src/services/bitmovin.codec.ts
+++ b/src/services/bitmovin.codec.ts
@@ -7,6 +7,10 @@ export const videoCodecConfigurations = [
   '33241c7e-4cc8-4fa3-907c-14393c158324'  //Bitmovin HD H264 240 kbit/s 384px
 ];
 
+export const debugCodecConfigurations = [
+  '33241c7e-4cc8-4fa3-907c-14393c158324'  //Bitmovin HD H264 240 kbit/s 384px
+]
+
 export const audioCodecConfiguration = [
   '9d80ae8b-b9b0-41d2-b049-8729a83b8f26'
 ];

--- a/src/services/contentful.service.ts
+++ b/src/services/contentful.service.ts
@@ -20,12 +20,13 @@ export function getAssetUrl(videoId: string): Promise<string> {
     .catch((ex) => { throw ex; });
 }
 
-export async function updateContentData(entryId, assetId) {
-  const bitmovinUrl = `${process.env.CLOUDFRONT_DOMAIN}bitmovin/${assetId}/manifest.m3u8`;
+export async function updateContentData(contentData: ContentData) {
+  const bitmovinUrl = `${process.env.CLOUDFRONT_DOMAIN}bitmovin/${contentData.videoId}/manifest.m3u8`;
 
+  console.log(`Attempting contentful update for Entry: ${contentData.id}\nRequestId: ${contentData.requestId}`);
   return managementClient.getSpace(process.env.CONTENTFUL_SPACE_ID)
     .then((space) => space.getEnvironment(process.env.CONTENTFUL_ENV))
-    .then((environment) => environment.getEntry(entryId))
+    .then((environment) => environment.getEntry(contentData.id))
     .then((entry) => {
       let entry_bitmovin_url: string = entry.fields.bitmovin_url ? entry.fields.bitmovin_url['en-US'] : '';
 
@@ -35,10 +36,10 @@ export async function updateContentData(entryId, assetId) {
         return entry.update()
           .then((entry) => {
             entry.publish();
-            console.log(`Entry ${entry.sys.id} bitmovin url updated to ${bitmovinUrl}`);
+            console.log(`Entry ${entry.sys.id} bitmovin url updated to ${bitmovinUrl} => RequestID: ${contentData.requestId}`);
           }).catch(console.error);
       } else {
-        console.log(`Bitmovin URL in entry already up to date`);
+        console.log(`Bitmovin URL in entry already up to date => RequestID: ${contentData.requestId}`);
       }
     }).catch(console.error);
 }


### PR DESCRIPTION
Added request id to responses for tracking
Endpoint now responds immediately to prevent contentful for doing
retries
added debug codec to minimize encoding minute usage
moved contentful update to only be called once in the code instead of
twice
simplified parameters for contentful functions